### PR TITLE
grammar: Do not declare dictionaries as objects

### DIFF
--- a/grammars/cwl.cson
+++ b/grammars/cwl.cson
@@ -7,20 +7,20 @@
     'name': 'string.quoted.single.cwl'
     'begin': "'"
     'end': "'"
-    'patterns':  ({
+    'patterns':  {
       'name': 'constant.character.escape.cwl'
       'match': '\\.'
-      })
+      }
   },
   {
     # double quote string
     'name': 'string.quoted.double.cwl'
     'begin': '"'
     'end': '"'
-    'patterns':  ({
+    'patterns':  {
       'name': 'constant.character.escape.cwl'
       'match': '\\.'
-      })
+      }
   },
   {
     # keyword


### PR DESCRIPTION
Hi @manabuishii! As you probably know, we're using this `language-cwl` package to provide CWL syntax highlighting for GitHub.

I'm working on some improvements for our highlighting system and I've noticed that our engine is having some issues parsing grammars in this repository.

More specifically: You seem to be wrapping some of the `patterns` dictionaries in parentheses, which causes some CSON parsers to interpret the dictionary as an object.

The simple change proposed here fixes the issue in a backwards-compatible way. I'd appreciate if you could merge it!