### PR TITLE
grammar: The `patterns` object must be encased in an array

### DIFF
--- a/grammars/cwl.cson
+++ b/grammars/cwl.cson
@@ -7,20 +7,20 @@
     'name': 'string.quoted.single.cwl'
     'begin': "'"
     'end': "'"
-    'patterns':  {
+    'patterns':  [{
       'name': 'constant.character.escape.cwl'
       'match': '\\.'
-      }
+      }]
   },
   {
     # double quote string
     'name': 'string.quoted.double.cwl'
     'begin': '"'
     'end': '"'
-    'patterns':  {
+    'patterns':  [{
       'name': 'constant.character.escape.cwl'
       'match': '\\.'
-      }
+      }]
   },
   {
     # keyword


### PR DESCRIPTION
Hello again @manabuishii and _sorry_ for wasting your time. I've ran our integration tests again after you merged #6 and I've finally discovered the underlying issue that was causing the documents to not render properly.

My previous fix was _not_ correct: the issue is that the parens were meant to be square brackets `[]` because the patterns list is supposed to be an array! When the patterns list is not enclosed in an array, the parser just ignores it, causing weird rendering issues.

I'm so sorry I sent you the wrong fix earlier. I promise this is now correct -- I've manually verified it in Atom and in our integration tests.

Thank you!

cc @mr-c